### PR TITLE
fix(import): handle importing PIL on case insensitive filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,26 @@ An elegant and responsive static site generator for displaying your photography 
 
 ## Installation
 
+Make sure python3 is installed and then create a virtual environment for f2.8gallery:
+
+Linux or Mac OS:
+
 ```
 git clone https://github.com/asmartin/f2.8gallery.git
 cd f2.8gallery
-python3 -m venv env
+python -m venv env
 source env/bin/activate
-pip3 install -r requirements.txt
+pip install -r requirements.txt
+```
+
+Windows:
+
+```
+git clone https://github.com/asmartin/f2.8gallery.git
+cd f2.8gallery
+python -m venv env
+env/Scripts/activate
+pip install -r requirements.txt
 ```
 
 ## Building Your Site
@@ -46,17 +60,16 @@ Now, place your original, full-size JPGs in each of these directories. Then, cre
 Once you're ready, build your site:
 
 ```
-source env/bin/activate
-./f2.8gallery.py --title "John Smith Photos" --author "John Smith" /path/to/galleries /path/to/output
+python f2.8gallery.py --title "John Smith Photos" --author "John Smith" galleries output
 ```
 
 After your site is built, you can serve it locally to review before publishing online:
 
 ```
-python3 -m http.server --directory /path/to/output
+python -m http.server --directory output
 ```
 
-Now visit http://localhost:8000 to view your site. When you're ready to publish, simply sync `/path/to/output` to your hosting platform.
+Now visit http://localhost:8000 to view your site. When you're ready to publish, simply sync `output` to your hosting platform.
 
 ## Libraries
 

--- a/f2.8gallery.py
+++ b/f2.8gallery.py
@@ -1,14 +1,12 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import datetime
 import os
 import re
 import shutil
 import sys
-import urllib
 from jinja2 import Environment, FileSystemLoader
 from pprint import pprint
-from jinja2 import Environment, PackageLoader
 from urllib.request import urlretrieve
 
 # PIL may be installed as "Pil" or similar on case-insensitive filesytems
@@ -19,6 +17,7 @@ except ImportError:
         from Pil import Image
     except ImportError:
         from pil import Image
+
 
 def regex_replace(s, find, replace):
     """Implement a regex filter for jinja2"""
@@ -86,18 +85,30 @@ def main():
 
     # create necessary directories if they don't exist
     create_if_not_exists(args.output)
-    thumbnails_dir = f"{args.output}/thumbnails"
+    thumbnails_dir = f"{args.output}{os.path.sep}thumbnails"
     create_if_not_exists(thumbnails_dir)
-    create_if_not_exists(f"{args.output}/assets")
-    create_if_not_exists(f"{args.output}/assets/img")
-    create_if_not_exists(f"{args.output}/assets/js")
-    create_if_not_exists(f"{args.output}/assets/css")
-    create_if_not_exists(f"{args.output}/assets/css/font")
+    create_if_not_exists(f"{args.output}{os.path.sep}assets")
+    create_if_not_exists(f"{args.output}{os.path.sep}assets{os.path.sep}img")
+    create_if_not_exists(f"{args.output}{os.path.sep}assets{os.path.sep}js")
+    create_if_not_exists(f"{args.output}{os.path.sep}assets{os.path.sep}css")
+    create_if_not_exists(
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}font"
+    )
 
-    shutil.copytree(args.galleries, f"{args.output}/galleries", dirs_exist_ok=True)
-    shutil.copytree("assets/img", f"{args.output}/assets/img", dirs_exist_ok=True)
-    shutil.copytree("assets/css", f"{args.output}/assets/css", dirs_exist_ok=True)
-    shutil.copytree("assets/root", f"{args.output}", dirs_exist_ok=True)
+    shutil.copytree(
+        args.galleries, f"{args.output}{os.path.sep}galleries", dirs_exist_ok=True
+    )
+    shutil.copytree(
+        f"assets{os.path.sep}img",
+        f"{args.output}{os.path.sep}assets{os.path.sep}img",
+        dirs_exist_ok=True,
+    )
+    shutil.copytree(
+        f"assets{os.path.sep}css",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css",
+        dirs_exist_ok=True,
+    )
+    shutil.copytree(f"assets{os.path.sep}root", f"{args.output}", dirs_exist_ok=True)
 
     thumbnail_size_scaled_up = (
         args.thumbwidth * 1.2
@@ -110,8 +121,8 @@ def main():
     gallery_paths = [x[0] for x in os.walk(args.galleries)]
     for path in gallery_paths:
         if path != args.galleries:
-            gallery_name = path.split("/")[-1]
-            thumbnail_dir = f"{thumbnails_dir}/{gallery_name}"
+            gallery_name = path.split(os.path.sep)[-1]
+            thumbnail_dir = f"{thumbnails_dir}{os.path.sep}{gallery_name}"
             galleries[gallery_name] = {}
             galleries[gallery_name]["gallery_dir"] = path
             galleries[gallery_name]["thumbnail_dir"] = thumbnail_dir
@@ -120,11 +131,11 @@ def main():
             for file in os.listdir(path):
                 gallery_names.append(gallery_name)
                 galleries[gallery_name]["files"].append(file)
-                thumbnail = f"{thumbnail_dir}/{file}"
+                thumbnail = f"{thumbnail_dir}{os.path.sep}{file}"
                 if not os.path.isfile(thumbnail):
                     if args.debug:
                         print(f"Creating thumbnail for {file} as {thumbnail}")
-                    image = Image.open(f"{path}/{file}")
+                    image = Image.open(f"{path}{os.path.sep}{file}")
                     image.thumbnail(thumbnail_wh)
                     image.save(thumbnail)
 
@@ -135,7 +146,7 @@ def main():
     env = Environment(loader=FileSystemLoader("."))
     env.filters["regex_replace"] = regex_replace
     template = env.get_template("index.j2")
-    index = open(f"{args.output}/index.html", "w")
+    index = open(f"{args.output}{os.path.sep}index.html", "w")
     index.write(
         template.render(
             webpage_name=args.title,
@@ -152,39 +163,39 @@ def main():
     print("downloading required libraries")
     urlretrieve(
         "https://code.jquery.com/jquery-3.7.1.slim.min.js",
-        f"{args.output}/assets/js/jquery.min.js",
+        f"{args.output}{os.path.sep}assets{os.path.sep}js{os.path.sep}jquery.min.js",
     )
     urlretrieve(
         "https://raw.githubusercontent.com/nanostudio-org/nanogallery2/master/dist/css/nanogallery2.min.css",
-        f"{args.output}/assets/css/nanogallery2.min.css",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}nanogallery2.min.css",
     )
     urlretrieve(
         "https://raw.githubusercontent.com/nanostudio-org/nanogallery2/master/dist/jquery.nanogallery2.min.js",
-        f"{args.output}/assets/js/jquery.nanogallery2.min.js",
+        f"{args.output}{os.path.sep}assets{os.path.sep}js{os.path.sep}jquery.nanogallery2.min.js",
     )
     urlretrieve(
         "https://raw.githubusercontent.com/kylefox/jquery-modal/v0.9.1/jquery.modal.min.js",
-        f"{args.output}/assets/js/jquery.modal.min.js",
+        f"{args.output}{os.path.sep}assets{os.path.sep}js{os.path.sep}jquery.modal.min.js",
     )
     urlretrieve(
         "https://raw.githubusercontent.com/kylefox/jquery-modal/v0.9.1/jquery.modal.min.css",
-        f"{args.output}/assets/css/jquery.modal.min.css",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}jquery.modal.min.css",
     )
     urlretrieve(
         "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css",
-        f"{args.output}/assets/css/pure-min.css",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}pure-min.css",
     )
     urlretrieve(
         "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css",
-        f"{args.output}/assets/css/grids-responsive-min.css",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}grids-responsive-min.css",
     )
     urlretrieve(
         "https://github.com/nanostudio-org/nanogallery2/raw/master/dist/css/font/ngy2_icon_font.woff",
-        f"{args.output}/assets/css/font/ngy2_icon_font.woff",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}font{os.path.sep}ngy2_icon_font.woff",
     )
     urlretrieve(
         "https://github.com/nanostudio-org/nanogallery2/raw/master/dist/css/font/ngy2_icon_font.woff2",
-        f"{args.output}/assets/css/font/ngy2_icon_font.woff2",
+        f"{args.output}{os.path.sep}assets{os.path.sep}css{os.path.sep}font{os.path.sep}ngy2_icon_font.woff2",
     )
     print(f"site successfully generated at {args.output}!")
 

--- a/f2.8gallery.py
+++ b/f2.8gallery.py
@@ -7,11 +7,18 @@ import shutil
 import sys
 import urllib
 from jinja2 import Environment, FileSystemLoader
-from PIL import Image
 from pprint import pprint
 from jinja2 import Environment, PackageLoader
 from urllib.request import urlretrieve
 
+# PIL may be installed as "Pil" or similar on case-insensitive filesytems
+try:
+    from PIL import Image
+except ImportError:
+    try:
+        from Pil import Image
+    except ImportError:
+        from pil import Image
 
 def regex_replace(s, find, replace):
     """Implement a regex filter for jinja2"""


### PR DESCRIPTION
As described in #1, the `PIL` may get installed as `Pil` on case-insensitive filesystems, so account for that situation when attempting to import it