### PR TITLE
Fix Windows path separators breaking gallery when opened via file://

### DIFF
--- a/f2.8gallery.py
+++ b/f2.8gallery.py
@@ -126,6 +126,8 @@ def main():
             galleries[gallery_name] = {}
             galleries[gallery_name]["gallery_dir"] = path
             galleries[gallery_name]["thumbnail_dir"] = thumbnail_dir
+            galleries[gallery_name]["gallery_url"] = f"galleries/{gallery_name}"
+            galleries[gallery_name]["thumbnail_url"] = f"thumbnails/{gallery_name}"
             galleries[gallery_name]["files"] = []
             create_if_not_exists(thumbnail_dir)
             for file in os.listdir(path):

--- a/index.j2
+++ b/index.j2
@@ -61,17 +61,17 @@
           "thumbnailDisplayInterval":            30
         }'>
           {% for file in gallery.files %}
-          <a href="galleries/{{ gallery.gallery_dir.replace(base, '') }}/{{ file }}" data-ngThumb="{{ gallery.thumbnail_dir.replace(output, '') | regex_replace('^/', '') }}/{{ file }}"></a>
+          <a href="{{ gallery.gallery_url }}/{{ file }}" data-ngThumb="{{ gallery.thumbnail_url }}/{{ file }}"></a>
           {% endfor %}
 	</div><br/>
         {% endfor %}
     </div>
     <div class="footer"><p>&copy; {{ author }} {{ now.strftime('%Y') }}</p></div>
     <div id="about" class="modal">
-      <p class="modal-body">{% include 'about.html' %}</p>
+      <div class="modal-body">{% include 'about.html' %}</div>
     </div>
     <div id="contact" class="modal">
-      <p class="modal-body">{% include 'contact.html' %}</p>
+      <div class="modal-body">{% include 'contact.html' %}</div>
     </div>
     <script type="text/javascript">
      $("#fade").modal({


### PR DESCRIPTION
Fix Windows path separators breaking gallery when opened via file://

On Windows, os.path.sep introduces backslashes into generated URLs.
This results in broken image links when opening index.html directly via file://.

This change introduces explicit URL-safe gallery_url and thumbnail_url fields and simplifies the template logic, ensuring forward slashes are always used in generated HTML.

Also replaces invalid `<p> `wrapper around modal includes with `<div>`.